### PR TITLE
Add mpv-version.

### DIFF
--- a/mpv.el
+++ b/mpv.el
@@ -362,5 +362,14 @@ of \\[universal-argument] will add another `mpv-seek-step' seconds."
   (interactive)
   (mpv--enqueue '("revert-seek") #'ignore))
 
+;;;###autoload
+(defun mpv-version ()
+  "Return mpv version."
+  (interactive)
+  (let ((version (cadr (split-string (car (process-lines "mpv" "--version"))))))
+    (prog1 version
+      (if (called-interactively-p 'interactive)
+	  (message "%s" version)))))
+
 (provide 'mpv)
 ;;; mpv.el ends here

--- a/mpv.el
+++ b/mpv.el
@@ -364,12 +364,14 @@ of \\[universal-argument] will add another `mpv-seek-step' seconds."
 
 ;;;###autoload
 (defun mpv-version ()
-  "Return mpv version."
+  "Return the mpv version string.
+When called interactively, also show a more verbose version in
+the echo area."
   (interactive)
-  (let ((version (cadr (split-string (car (process-lines "mpv" "--version"))))))
+  (let ((version (cadr (split-string (car (process-lines mpv-executable "--version"))))))
     (prog1 version
       (if (called-interactively-p 'interactive)
-	  (message "%s" version)))))
+	  (message "mpv %s" version)))))
 
 (provide 'mpv)
 ;;; mpv.el ends here


### PR DESCRIPTION
Motivation: [mpv 0.33](https://github.com/mpv-player/mpv/commit/e9e93b4dbe748cd341a6fbea355e6ba013ada81b) introduces lots of playlist commands. It would thus make sense to compare `mpv` version string to see if a command is supported or not.  