### PR TITLE
Support playing from url (mpv-play-url)

### DIFF
--- a/mpv.el
+++ b/mpv.el
@@ -220,18 +220,11 @@ passes unsolicited event messages to `mpv-on-event-hook'."
   "Return if URI is an HTTP(S) URL."
   (member (url-type (url-generic-parse-url uri)) '("http" "https")))
 
-(defun mpv--url-parse-header-at-point ()
-  "Parse the first header line such as \"HTTP/1.1 200 OK\"."
-  (when (re-search-forward "\\=[ \t\n]*HTTP/\\([0-9\\.]+\\) +\\([0-9]+\\)" nil t)
-    (list :version (match-string 1)
-          :code (string-to-number (match-string 2)))))
-
 (defun mpv--url-reachable-p (url)
   "Test if the given URL is reachable with 2xx status code."
   (condition-case _
       (with-current-buffer (url-retrieve-synchronously url nil nil 5)
-        (goto-char (point-min))
-        (let ((status (plist-get (mpv--url-parse-header-at-point) :code)))
+        (let ((status (url-http-symbol-value-in-buffer 'url-http-response-status (current-buffer))))
           (and (>= status 200) (< status 300))))
     ((debug error) (error "Could not successfully reach URL: %s" url))))
 


### PR DESCRIPTION
Successor of #13 

> Allows users to pass a valid HTTP(S) URL to the mpv-play command, both interactively and non-interactively.
> 
> Often I find myself using mpv with its youtube-dl counterpart that allows direct streaming of online content through mpv.
> This allows for non-filename arguments in the interactive mpv-play command, by locally enabling url-handler-mode for the scope of the interactive completion command and conditionally expanding the argument if it is a non-absolute filepath.
> 
> Using it this way does require the user to have youtube-dl installed on their system, so in case that's not sufficiently self-explanatory (I guess anyone who would want to use mpv that way would have found that by now?), I can add something to the documentation about it.
> 
> My apologies for the unwanted indentation changes, it appears I have a different lisp-indent-function set than you.
> 
> Edit: I only just saw #11 in the issues tab. If you would prefer a separate interactive command to handle this that would be a minor change

Changed it to a separate `mpv-play-url` command.

Completion frameworks such as `ivy` don't play well with `url-handler-mode` and yanking urls into the minibuffer **out of the box**, so simply applying `read-string` for the URL insertion seemed more appropriate and portable