### PR TITLE
Add volume control.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Among others, mpv.el provides
 - `mpv-kill`
 - `mpv-seek-forward` / `mpv-seek-backward`
 - `mpv-speed-increase` / `mpv-speed-decrease`
+- `mpv-volume-increase` / `mpv-speed-volume`
 - `mpv-insert-playback-position`
 - `mpv-seek-to-position-at-point`
 

--- a/mpv.el
+++ b/mpv.el
@@ -316,10 +316,9 @@ This can be used with the `org-open-at-point-functions' hook."
 (defun mpv-speed-increase (steps)
   "Increase playback speed by STEPS factors of `mpv-speed-step'."
   (interactive "p")
-  (let ((factor (* (abs steps)
-                   (if (> steps 0)
-                       mpv-speed-step
-                     (/ 1 mpv-speed-step)))))
+  (let ((factor (if (>= steps 0)
+                    (* steps mpv-speed-step)
+                  (/ 1 (* (- steps) mpv-speed-step)))))
     (mpv--enqueue `("multiply" "speed" ,factor) #'ignore)))
 
 ;;;###autoload
@@ -338,10 +337,9 @@ This can be used with the `org-open-at-point-functions' hook."
 (defun mpv-volume-increase (steps)
   "Increase playback volume by STEPS factors of `mpv-volume-step'."
   (interactive "p")
-  (let ((factor (* (abs steps)
-                   (if (> steps 0)
-                       mpv-volume-step
-                     (/ 1 mpv-volume-step)))))
+  (let ((factor (if (>= steps 0)
+                    (* steps mpv-volume-step)
+                  (/ 1 (* (- steps) mpv-volume-step)))))
     (mpv--enqueue `("multiply" "volume" ,factor) #'ignore)))
 
 ;;;###autoload

--- a/mpv.el
+++ b/mpv.el
@@ -63,6 +63,11 @@
   :type 'number
   :group 'mpv)
 
+(defcustom mpv-volume-step 1.50
+  "Scale factor used when adjusting volume."
+  :type 'number
+  :group 'mpv)
+
 (defcustom mpv-seek-step 5
   "Step size in seconds used when seeking."
   :type 'number
@@ -322,6 +327,28 @@ This can be used with the `org-open-at-point-functions' hook."
   "Decrease playback speed by STEPS factors of `mpv-speed-step'."
   (interactive "p")
   (mpv-speed-increase (- steps)))
+
+;;;###autoload
+(defun mpv-volume-set (factor)
+  "Set playback volume to FACTOR."
+  (interactive "nFactor: ")
+  (mpv--enqueue `("set" "volume" ,(abs factor)) #'ignore))
+
+;;;###autoload
+(defun mpv-volume-increase (steps)
+  "Increase playback volume by STEPS factors of `mpv-volume-step'."
+  (interactive "p")
+  (let ((factor (* (abs steps)
+                   (if (> steps 0)
+                       mpv-volume-step
+                     (/ 1 mpv-volume-step)))))
+    (mpv--enqueue `("multiply" "volume" ,factor) #'ignore)))
+
+;;;###autoload
+(defun mpv-volume-decrease (steps)
+  "Decrease playback volume by STEPS factors of `mpv-volume-step'."
+  (interactive "p")
+  (mpv-volume-increase (- steps)))
 
 (defun mpv--raw-prefix-to-seconds (arg)
   "Convert raw prefix argument ARG to seconds using `mpv-seek-step'.


### PR DESCRIPTION
Added `mpv-volume-set`, `mpv-volume-increase`, `mpv-volume-decrease`
and `mpv-volume-step`. Works the same way as its speed counterpart.

Also, what do you think about implementing transient keymap with the `seek`, `speed` and `volume` command?