### PR TITLE
Fix playlist append behavior for mpv >= 0.38

### DIFF
--- a/mpv.el
+++ b/mpv.el
@@ -487,19 +487,17 @@ See `mpv-start' if you need to pass further arguments and
   "Append THING to the current mpv playlist.
 
 If ARGS are provided, they are passed as per-file options to mpv."
-  (let* ((req-idx (version<= "0.38"
-                             (replace-regexp-in-string
-                              "[^0-9.]" "" (mpv-get-property "mpv-version"))))
-         ;; mpv above 0.38.0 requires insert position
-         (opts-args (append '("append")
-                            (when req-idx '("-1"))
-                            (list
-                             (string-join
-                              (mapcar (lambda (arg)
-                                        (string-trim-left arg "--"))
-                                      args)
-                              ",")))))
-    (apply #'mpv-run-command "loadfile" thing opts-args))
+  (let ((mpv-version (replace-regexp-in-string
+                      "[^0-9.]" "" (mpv-get-property "mpv-version"))))
+    (apply #'mpv-run-command "loadfile" thing
+           `("append"
+             ;; mpv above 0.38.0 requires insert position argument
+             ,@(when (version<= "0.38" mpv-version) '("-1"))
+             ,(string-join
+               (mapcar (lambda (arg)
+                         (string-trim-left arg "--"))
+                       args)
+               ","))))
   (when-let* ((count (mpv-get-property "playlist-count"))
               (index (1- count))
               (filename (mpv-get-property (format "playlist/%d/filename" index))))

--- a/mpv.el
+++ b/mpv.el
@@ -487,12 +487,19 @@ See `mpv-start' if you need to pass further arguments and
   "Append THING to the current mpv playlist.
 
 If ARGS are provided, they are passed as per-file options to mpv."
-  (mpv-run-command "loadfile" thing "append"
-                   (string-join
-                    (mapcar (lambda (arg)
-                              (string-trim-left arg "--"))
-                            args)
-                    ","))
+  (let* ((req-idx (version<= "0.38"
+                             (replace-regexp-in-string
+                              "[^0-9.]" "" (mpv-get-property "mpv-version"))))
+         ;; mpv above 0.38.0 requires insert position
+         (opts-args (append '("append")
+                            (when req-idx '("-1"))
+                            (list
+                             (string-join
+                              (mapcar (lambda (arg)
+                                        (string-trim-left arg "--"))
+                                      args)
+                              ",")))))
+    (apply #'mpv-run-command "loadfile" thing opts-args))
   (when-let* ((count (mpv-get-property "playlist-count"))
               (index (1- count))
               (filename (mpv-get-property (format "playlist/%d/filename" index))))


### PR DESCRIPTION
Starting with mpv 0.38, the [`loadfile`](https://mpv.io/manual/stable/#command-interface-[%3Coptions%3E]]]) command gained an **insertion index argument** as a third parameter, which breaks prior usage passing per-file options directly.\
See also: [mpv interface changes documentation (release 0.38)](https://github.com/mpv-player/mpv/blob/02254b92dd237f03aa0a151c2a68778c4ea848f9/DOCS/interface-changes.rst)

This PR updates `mpv--playlist-append` to inspect the mpv version (by extracting digits from `mpv-version`) and insert `"-1"` when running with mpv **0.38 or newer**.

As a result, appending with per-file options works both on older versions (< 0.38) and newer versions (≥ 0.38).
